### PR TITLE
Auto-generated. Updating Vectara public protos. (3a90478acffd7a07dbb4…

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -7,7 +7,48 @@ option go_package = "vectara.com/public/proto/common";
 
 package com.vectara;
 
-// Request to delete a document from an index.
+// Languages supported by Vectara.
+message Language {
+  enum Code {
+    UNKNOWN = 0;
+
+    // English.
+    ENG = 1;
+    // German.
+    DEU = 2;
+    // France.
+    FRA = 3;
+    // Chinese.
+    ZHO = 4;
+    // Korean.
+    KOR = 5;
+    // Arabic.
+    ARA = 6;
+    // Russian.
+    RUS = 7;
+    // Thai.
+    THA = 8;
+    // Dutch.
+    NLD = 9;
+    // Italian.
+    ITA = 10;
+    // Portuguese.
+    POR = 11;
+    // Spanish.
+    SPA = 12;
+    // Japanese.
+    JPN = 13;
+    // Polish.
+    POL = 14;
+    // Turkish.
+    TUR = 15;
+
+    // Let the platform detect the language.
+    AUTO = 5000;
+  }
+}
+
+  // Request to delete a document from an index.
 message DeleteDocumentRequest {
   // The Customer ID to issue the request for.
   int64 customer_id = 1;

--- a/serving.proto
+++ b/serving.proto
@@ -152,6 +152,10 @@ message Summary {
   // The summary text.
   string text = 10;
 
+  // ISO 639 language code of the summary. If the requested language was set to "AUTO", the
+  // summary language is the same as the auto-detected language of the query.
+  string lang = 15;
+
 
   // Statuses are marked “repeated” for consistency and flexibility. A failed
   // summary should bubble up into the status code of the entire ResponseSet.


### PR DESCRIPTION
…65456db4e1ec4f95ab82).

# Heads up!
These protobufs in this repository are automatically generated from Vectara and
the repository is read-only for the general public.  As a result, we do not
accept pull requests to this GitHub repository.

If you have feedback on Vectara or its APIs, please let us know in our
forums: https://discuss.vectara.com/
