### PR TITLE
Auto-generated. Updating Vectara public protos. (1b26b7abcf5cde0e29d2…

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -16,7 +16,7 @@ message Language {
     ENG = 1;
     // German.
     DEU = 2;
-    // France.
+    // French.
     FRA = 3;
     // Chinese.
     ZHO = 4;

--- a/serving.proto
+++ b/serving.proto
@@ -53,8 +53,8 @@ message CorpusKey {
 
 
 message SummarizationRequest {
-  // The summarizer+prompt combination to use for summarization.
-  uint32 summarizer_prompt_id = 5;
+  // The name of the summarizer+prompt combination to use for summarization.
+  string summarizer_prompt_name = 3;
   // Maximum number of results to summarize.
   uint32 max_summarized_results = 15;
   // ISO 639-1 or ISO 639-3 language code for the response, or "auto" to indicate that


### PR DESCRIPTION
…2d2f3059cffe72322861).

# Heads up!
These protobufs in this repository are automatically generated from Vectara and
the repository is read-only for the general public.  As a result, we do not
accept pull requests to this GitHub repository.

If you have feedback on Vectara or its APIs, please let us know in our
forums: https://discuss.vectara.com/
