### PR TITLE
Auto-generated. Updating Vectara public protos. (396dada5b77787f27cfa…

### DIFF
--- a/services.proto
+++ b/services.proto
@@ -62,14 +62,9 @@ service QueryService {
     };
   }
 
-
   // A streamed response interface when lower latency is absolutely critical.
   rpc StreamQuery(com.vectara.serving.BatchQueryRequest)
           returns (stream com.vectara.serving.QueryResponsePart) {
-    option (google.api.http) = {
-      post: "/v1/stream-query"
-      body: "*"
-    };
   }
 }
 


### PR DESCRIPTION
…5fae54b384cb770bc3da).

# Heads up!
These protobufs in this repository are automatically generated from Vectara and
the repository is read-only for the general public.  As a result, we do not
accept pull requests to this GitHub repository.

If you have feedback on Vectara or its APIs, please let us know in our
forums: https://discuss.vectara.com/
